### PR TITLE
Fix logging when no rsyslog host is configured

### DIFF
--- a/src/twig_event_handler.erl
+++ b/src/twig_event_handler.erl
@@ -64,11 +64,16 @@ handle_call({set_level, Level}, State) ->
     {ok, ok, State#state{level = Level}};
 
 handle_call(load_config, State) ->
-    Host = case inet:getaddr(get_env(host, undefined), inet) of
-    {ok, Address} ->
-        Address;
-    {error, _} ->
-        undefined
+    Host = case get_env(host, undefined) of
+        undefined ->
+            undefined;
+        SyslogHost ->
+            case inet:getaddr(SyslogHost, inet) of
+                {ok, Address} ->
+                    Address;
+                {error, _} ->
+                    undefined
+            end
     end,
     NewState = State#state{
         host = Host,


### PR DESCRIPTION
The call to `inet:getaddr/2` will return a valid IP on `*.cloudant.com`
hosts due to our DNS configuration. This avoids the entire call when we
have not configured a syslog host.

This change was motivated by Jenkins which wasn't logging during `make
check` runs.

BugzId: 26411
